### PR TITLE
Various improvements including OTA updates and additional buttons and sensors

### DIFF
--- a/Firmware-Atmega/.gitignore
+++ b/Firmware-Atmega/.gitignore
@@ -1,1 +1,2 @@
 .pio
+.vscode

--- a/Firmware-ESP/.gitignore
+++ b/Firmware-ESP/.gitignore
@@ -1,2 +1,3 @@
 .pio
+.vscode
 include/credentials.h

--- a/Firmware-ESP/include/config.h
+++ b/Firmware-ESP/include/config.h
@@ -7,4 +7,11 @@
 
 // How often should new devices be queried
 #define QUERY_NEW_DEVICES_INTERVAL 60 // seconds
+
+// Enables the ability to silence the alarm from Home Assistant. Comment out the below line to disable.
+#define ENABLE_SILENCE_ALARM
+
+// Enables the ability to trigger an alarm from Home Assistant. Comment out the below line to disable.
+#define ENABLE_TRIGGER_ALARM
+
 #endif

--- a/Firmware-ESP/include/config.h
+++ b/Firmware-ESP/include/config.h
@@ -1,6 +1,10 @@
 #ifndef CONFIG_H
 #define CONFIG_H 1
 
-#define DEVICE_ID 0x317E33
+// Device ID for home assistant. Shouldn't need to change unless there is a 
+// clash with another home assistant device or you need more than one ws2mqtt instance.
+#define DEVICE_ID 0x317E33 
+
+// How often should new devices be queried
 #define QUERY_NEW_DEVICES_INTERVAL 60 // seconds
 #endif

--- a/Firmware-ESP/include/config.h
+++ b/Firmware-ESP/include/config.h
@@ -9,9 +9,9 @@
 #define QUERY_NEW_DEVICES_INTERVAL 60 // seconds
 
 // Enables the ability to silence the alarm from Home Assistant. Comment out the below line to disable.
-#define ENABLE_SILENCE_ALARM
+//#define ENABLE_SILENCE_ALARM
 
 // Enables the ability to trigger an alarm from Home Assistant. Comment out the below line to disable.
-#define ENABLE_TRIGGER_ALARM
+//#define ENABLE_TRIGGER_ALARM
 
 #endif

--- a/Firmware-ESP/include/credentials.h.example
+++ b/Firmware-ESP/include/credentials.h.example
@@ -7,4 +7,7 @@
 #define MQTT_HOST "" // do not include http e.g. "my.mqttserver.local" or "192.168.0.100"
 #define MQTT_USERNAME ""
 #define MQTT_PASSWORD ""
+
+#define OTA_PASSWORD "WS2MQTTPassword"
+
 #endif

--- a/Firmware-ESP/include/credentials.h.example
+++ b/Firmware-ESP/include/credentials.h.example
@@ -4,7 +4,7 @@
 #define WIFI_SSID ""
 #define WIFI_PSK ""
 
-#define MQTT_HOST ""
+#define MQTT_HOST "" // do not include http e.g. "my.mqttserver.local" or "192.168.0.100"
 #define MQTT_USERNAME ""
 #define MQTT_PASSWORD ""
 #endif

--- a/Firmware-ESP/include/homeassistant.h
+++ b/Firmware-ESP/include/homeassistant.h
@@ -7,15 +7,29 @@
 
 #define HA_AUTODISCOVERY_PREFIX "homeassistant"
 
+#define BRIDGE_SENSOR_INTERVAL 10000 // milliseconds between sending bridge sensor updates
+
 void announceAllDevices();
 void publishAllCachedDeviceStates();
 
 void announceMQTTBridge();
 void announceMQTTBridgeEntities();
 void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic, bool enabled, char* icon);
+void announceMQTTBridgeSensorEntity(
+	char* name, 
+	char* sensor, 
+	char* dev_class, 
+	char* unit, 
+	bool diagnostic, 
+	bool enabled, 
+	char* icon
+);
 
 void addBridgeDescription(JsonObject dev);
 void sendMQTTBridgeEvent();
+
+void loopBridgeSensors();
+void sendMQTTBridgeSensor (char* sensor, char* sensor_value);
 
 void announceMQTTDevice(device_t device);
 void addDeviceDescription(JsonObject dev, device_t device);

--- a/Firmware-ESP/include/homeassistant.h
+++ b/Firmware-ESP/include/homeassistant.h
@@ -7,7 +7,7 @@
 
 #define HA_AUTODISCOVERY_PREFIX "homeassistant"
 
-#define BRIDGE_SENSOR_INTERVAL 10000 // milliseconds between sending bridge sensor updates
+#define BRIDGE_SENSOR_INTERVAL 10 // seconds between sending bridge sensor updates
 
 void announceAllDevices();
 void publishAllCachedDeviceStates();

--- a/Firmware-ESP/include/homeassistant.h
+++ b/Firmware-ESP/include/homeassistant.h
@@ -12,7 +12,7 @@ void publishAllCachedDeviceStates();
 
 void announceMQTTBridge();
 void announceMQTTBridgeEntities();
-void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic, bool enabled);
+void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic, bool enabled, char* icon);
 
 void addBridgeDescription(JsonObject dev);
 void sendMQTTBridgeEvent();

--- a/Firmware-ESP/include/homeassistant.h
+++ b/Firmware-ESP/include/homeassistant.h
@@ -12,7 +12,7 @@ void publishAllCachedDeviceStates();
 
 void announceMQTTBridge();
 void announceMQTTBridgeEntities();
-void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic);
+void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic, bool enabled);
 
 void addBridgeDescription(JsonObject dev);
 void sendMQTTBridgeEvent();

--- a/Firmware-ESP/include/wifi_inc.h
+++ b/Firmware-ESP/include/wifi_inc.h
@@ -6,6 +6,7 @@
 #include <PubSubClient.h>
 #include "credentials.h"
 #include "homeassistant.h"
+#include <ArduinoOTA.h>
 
 boolean reconnectMQTT();
 void mqttCallback(char* topic, byte* payload, unsigned int length);
@@ -13,4 +14,8 @@ void setupMQTT();
 void loopMQTT();
 
 void setupWifi();
+
+void setupOTA();
+void loopOTA();
+
 #endif

--- a/Firmware-ESP/include/wisafe2_packets.h
+++ b/Firmware-ESP/include/wisafe2_packets.h
@@ -64,6 +64,16 @@ typedef struct {
 	uint8_t stop;
 } pkt_tx_event_button_t;
 
+// Outgoing silence smoke message  {0x61, 0x000000, 0x80, 0x01, 0x7E};
+const uint8_t SPI_TX_SILENCE_SMOKE_BUTTON = 0x61;
+typedef struct {
+	uint8_t cmd;
+	uint32_t device_id:24;
+	uint8_t device_type;
+	uint8_t _unknown;
+	uint8_t stop;
+} pkt_tx_silence_smoke_button_t;
+
 const uint8_t SPI_RX_ERROR = 0x71;
 typedef struct {
 	uint8_t cmd;

--- a/Firmware-ESP/include/wisafe2_packets.h
+++ b/Firmware-ESP/include/wisafe2_packets.h
@@ -64,15 +64,17 @@ typedef struct {
 	uint8_t stop;
 } pkt_tx_event_button_t;
 
-// Outgoing silence smoke message  {0x61, 0x000000, 0x80, 0x01, 0x7E};
-const uint8_t SPI_TX_SILENCE_SMOKE_BUTTON = 0x61;
+// Outgoing silence message  
+// smoke {0x61, 0x000000, 0x80, 0x01, 0x7E};
+// co    {0x61, 0x000000, 0x40, 0x01, 0x7E};
+const uint8_t SPI_TX_SILENCE_BUTTON = 0x61;
 typedef struct {
 	uint8_t cmd;
 	uint32_t device_id:24;
 	uint8_t device_type;
 	uint8_t _unknown;
 	uint8_t stop;
-} pkt_tx_silence_smoke_button_t;
+} pkt_tx_silence_button_t;
 
 const uint8_t SPI_RX_ERROR = 0x71;
 typedef struct {

--- a/Firmware-ESP/include/wisafe2_packets.h
+++ b/Firmware-ESP/include/wisafe2_packets.h
@@ -70,6 +70,7 @@ typedef struct {
 // Outgoing silence message  
 // smoke {0x61, 0x000000, 0x80, 0x01, 0x7E};
 // co    {0x61, 0x000000, 0x40, 0x01, 0x7E};
+#ifdef ENABLE_SILENCE_ALARM
 const uint8_t SPI_TX_SILENCE_BUTTON = 0x61;
 typedef struct {
 	uint8_t cmd;
@@ -78,10 +79,12 @@ typedef struct {
 	uint8_t _unknown;
 	uint8_t stop;
 } pkt_tx_silence_button_t;
+#endif
 
 // Outgoing emergency message
 // smoke {0x50, 0x000000, 0x81, 0x00, 0x7E};
 // co    {0x50, 0x000000, 0x41, 0x00, 0x7E};
+#ifdef ENABLE_TRIGGER_ALARM
 const uint8_t SPI_TX_EMERGENCY_BUTTON = 0x50;
 typedef struct {
 	uint8_t cmd;
@@ -90,6 +93,7 @@ typedef struct {
 	uint8_t _unknown;
 	uint8_t stop;
 } pkt_tx_emergency_button_t;
+#endif
 
 // Receive error
 const uint8_t SPI_RX_ERROR = 0x71;

--- a/Firmware-ESP/include/wisafe2_packets.h
+++ b/Firmware-ESP/include/wisafe2_packets.h
@@ -82,7 +82,14 @@ typedef struct {
 // Outgoing emergency message
 // smoke {0x50, 0x000000, 0x81, 0x00, 0x7E};
 // co    {0x50, 0x000000, 0x41, 0x00, 0x7E};
-
+const uint8_t SPI_TX_EMERGENCY_BUTTON = 0x50;
+typedef struct {
+	uint8_t cmd;
+	uint32_t device_id:24;
+	uint8_t device_type;
+	uint8_t _unknown;
+	uint8_t stop;
+} pkt_tx_emergency_button_t;
 
 // Receive error
 const uint8_t SPI_RX_ERROR = 0x71;

--- a/Firmware-ESP/include/wisafe2_packets.h
+++ b/Firmware-ESP/include/wisafe2_packets.h
@@ -54,6 +54,9 @@ typedef struct {
 } pkt_rx_event_button_t;
 
 // Outgoing test message
+// smoke {0x70, 0x000000, 0x81, 0x01, 0x0000, 0x7E};
+// co    {0x70, 0x000000, 0x41, 0x01, 0x0000, 0x7E};
+// all   {0x70, 0x000000, 0xFF, 0x01, 0x0000, 0x7E};
 const uint8_t SPI_TX_EVENT_BUTTON = 0x70;
 typedef struct {
 	uint8_t cmd;
@@ -76,6 +79,12 @@ typedef struct {
 	uint8_t stop;
 } pkt_tx_silence_button_t;
 
+// Outgoing emergency message
+// smoke {0x50, 0x000000, 0x81, 0x00, 0x7E};
+// co    {0x50, 0x000000, 0x41, 0x00, 0x7E};
+
+
+// Receive error
 const uint8_t SPI_RX_ERROR = 0x71;
 typedef struct {
 	uint8_t cmd;

--- a/Firmware-ESP/include/wisafe2_tx.h
+++ b/Firmware-ESP/include/wisafe2_tx.h
@@ -14,7 +14,7 @@ void handleTX(uint8_t* msg, int length);
 void enqueueSPIMessage(uint8_t* msg);
 
 void sendWelcomeMsg();
-void sendTestButtonMsg();
+void sendTestButtonMsg(uint8_t device_type);
 void sendSilenceButtonMsg(uint8_t device_type);
 void sendDiagnosticRequest();
 void sendQuerySIDMap();

--- a/Firmware-ESP/include/wisafe2_tx.h
+++ b/Firmware-ESP/include/wisafe2_tx.h
@@ -15,7 +15,7 @@ void enqueueSPIMessage(uint8_t* msg);
 
 void sendWelcomeMsg();
 void sendTestButtonMsg();
-void sendSilenceSmokeButtonMsg();
+void sendSilenceButtonMsg(uint8_t device_type);
 void sendDiagnosticRequest();
 void sendQuerySIDMap();
 void sendQueryDiagnosticDetails(uint8_t sid, uint8_t subsubtype);

--- a/Firmware-ESP/include/wisafe2_tx.h
+++ b/Firmware-ESP/include/wisafe2_tx.h
@@ -16,6 +16,7 @@ void enqueueSPIMessage(uint8_t* msg);
 void sendWelcomeMsg();
 void sendTestButtonMsg(uint8_t device_type);
 void sendSilenceButtonMsg(uint8_t device_type);
+void sendEmergencyButtonMsg(uint8_t device_type);
 void sendDiagnosticRequest();
 void sendQuerySIDMap();
 void sendQueryDiagnosticDetails(uint8_t sid, uint8_t subsubtype);

--- a/Firmware-ESP/include/wisafe2_tx.h
+++ b/Firmware-ESP/include/wisafe2_tx.h
@@ -15,6 +15,7 @@ void enqueueSPIMessage(uint8_t* msg);
 
 void sendWelcomeMsg();
 void sendTestButtonMsg();
+void sendSilenceSmokeButtonMsg();
 void sendDiagnosticRequest();
 void sendQuerySIDMap();
 void sendQueryDiagnosticDetails(uint8_t sid, uint8_t subsubtype);

--- a/Firmware-ESP/platformio.ini
+++ b/Firmware-ESP/platformio.ini
@@ -23,7 +23,7 @@ upload_speed = 921600
 extends = env
 upload_protocol = espota
 ; IP address of the ESP32
-upload_port = 192.168.0.49
+upload_port = 
 ; Password must match that of OTA_PASSWORD in credentials.h
 upload_flags = --auth=WS2MQTTPassword
 

--- a/Firmware-ESP/platformio.ini
+++ b/Firmware-ESP/platformio.ini
@@ -18,6 +18,13 @@ framework = arduino
 monitor_filters = esp32_exception_decoder
 upload_speed = 921600
 
+[env:esp32_ota]
+;extends the settings from the [env:esp32] section
+extends = env
+upload_protocol = espota
+; IP address of the ESP32
+upload_port = 192.168.0.46
+upload_flags = --auth=WS2MQTTPassword
 
 lib_deps =
   bblanchon/ArduinoJson@^6.19.1

--- a/Firmware-ESP/platformio.ini
+++ b/Firmware-ESP/platformio.ini
@@ -19,11 +19,12 @@ monitor_filters = esp32_exception_decoder
 upload_speed = 921600
 
 [env:esp32_ota]
-;extends the settings from the [env:esp32] section
+; extends the settings from the [env] section for OTA updating
 extends = env
 upload_protocol = espota
 ; IP address of the ESP32
-upload_port = 192.168.0.46
+upload_port = 192.168.0.49
+; Password must match that of OTA_PASSWORD in credentials.h
 upload_flags = --auth=WS2MQTTPassword
 
 lib_deps =

--- a/Firmware-ESP/src/homeassistant.cpp
+++ b/Firmware-ESP/src/homeassistant.cpp
@@ -46,20 +46,28 @@ void announceMQTTBridge() {
 }
 
 void announceMQTTBridgeEntities() {
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test All Devices", (char*)"test_devices", false, true, (char*)"mdi:bell-cog"); //Test All Button
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test Smoke Devices", (char*)"test_smoke", false, false, (char*)"mdi:bell-cog"); //Test Smoke Button
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test CO Devices", (char*)"test_co", false, false, (char*)"mdi:bell-cog"); //Test CO Button
+	// Test
+	announceMQTTBridgeButtonEntity((char*)"Test All Devices", (char*)"test_devices", false, true, (char*)"mdi:bell-cog"); //Test All Button
+	announceMQTTBridgeButtonEntity((char*)"Test Smoke Devices", (char*)"test_smoke", false, false, (char*)"mdi:bell-cog"); //Test Smoke Button
+	announceMQTTBridgeButtonEntity((char*)"Test CO Devices", (char*)"test_co", false, false, (char*)"mdi:bell-cog"); //Test CO Button
 
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence Smoke Devices", (char*)"silence_smoke", false, false, (char*)"mdi:bell-sleep"); //Silence Smoke Button
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence CO Devices", (char*)"silence_co", false, false, (char*)"mdi:bell-sleep"); //Silence CO Button
+	// Silence
+	announceMQTTBridgeButtonEntity((char*)"Silence Smoke Devices", (char*)"silence_smoke", false, false, (char*)"mdi:bell-sleep"); //Silence Smoke Button
+	announceMQTTBridgeButtonEntity((char*)"Silence CO Devices", (char*)"silence_co", false, false, (char*)"mdi:bell-sleep"); //Silence CO Button
 
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Emergency Smoke", (char*)"emergency_smoke", false, false, (char*)"mdi:bell-sleep"); //Emergency Smoke Button
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Emergency CO", (char*)"emergency_co", false, false, (char*)"mdi:bell-sleep"); //Emergency CO Button
+	// Emergency
+	announceMQTTBridgeButtonEntity((char*)"Emergency Smoke", (char*)"emergency_smoke", false, false, (char*)"mdi:bell-sleep"); //Emergency Smoke Button
+	announceMQTTBridgeButtonEntity((char*)"Emergency CO", (char*)"emergency_co", false, false, (char*)"mdi:bell-sleep"); //Emergency CO Button
 
-	announceMQTTBridgeSensorEntity((char*)"WS2MQTT IP Address", (char*)"ip_addr", (char*)"None", (char*)"None", true, true, (char*)"mdi:ip-network"); //IP Address Sensor
-	announceMQTTBridgeSensorEntity((char*)"WS2MQTT RSSI", (char*)"rssi", (char*)"signal_strength", (char*)"dBm", true, true, (char*)"mdi:wifi"); //Wifi RSSI
-	announceMQTTBridgeSensorEntity((char*)"WS2MQTT MAC Address", (char*)"mac_addr", (char*)"None", (char*)"None", true, true, (char*)"mdi:wifi"); //Wifi Mac Address
-	announceMQTTBridgeSensorEntity((char*)"WS2MQTT SSID", (char*)"ssid", (char*)"None", (char*)"None", true, true, (char*)"mdi:wifi"); //Wifi SSID
+	// WiFi Sensors
+	announceMQTTBridgeSensorEntity((char*)"IP Address", (char*)"ip_addr", (char*)"None", (char*)"None", true, true, (char*)"mdi:ip-network"); //IP Address Sensor
+	announceMQTTBridgeSensorEntity((char*)"RSSI", (char*)"rssi", (char*)"signal_strength", (char*)"dBm", true, true, (char*)"mdi:wifi"); //Wifi RSSI
+	announceMQTTBridgeSensorEntity((char*)"MAC Address", (char*)"mac_addr", (char*)"None", (char*)"None", true, true, (char*)"mdi:wifi"); //Wifi Mac Address
+	announceMQTTBridgeSensorEntity((char*)"SSID", (char*)"ssid", (char*)"None", (char*)"None", true, true, (char*)"mdi:wifi"); //Wifi SSID
+
+	// Restart
+	announceMQTTBridgeButtonEntity((char*)"ESP Restart", (char*)"esp_restart", false, false, (char*)"mdi:restart"); // Restart Button
+	announceMQTTBridgeSensorEntity((char*)"Uptime", (char*)"esp_uptime", (char*)"duration", (char*)"s", true, false, (char*)"mdi:clock"); // Time since last restart
 }
 
 void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic, bool enabled, char* icon) {
@@ -178,6 +186,11 @@ void loopBridgeSensors () {
 
 		// SSID
 		sendMQTTBridgeSensor((char*)"ssid", (char*)WiFi.SSID().c_str());
+
+		// Uptime
+		char uptime[5];
+		sprintf(uptime, "%d", esp_timer_get_time()/1000000);
+		sendMQTTBridgeSensor((char*)"esp_uptime", (char*)uptime);
 
 		lastSensorPush = millis();
 	}
@@ -376,6 +389,9 @@ void handleMQTTCommand(char* command) {
 	}
 	else if (strncmp(command, "emergency_co", 12) == 0) {
 		sendEmergencyButtonMsg(DEVICE_TYPE_CO);
+	}
+	else if (strncmp(command, "esp_restart", 11) ==0) {
+		ESP.restart();
 	}
 
 }

--- a/Firmware-ESP/src/homeassistant.cpp
+++ b/Firmware-ESP/src/homeassistant.cpp
@@ -44,11 +44,11 @@ void announceMQTTBridge() {
 }
 
 void announceMQTTBridgeEntities() {
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test All Devices", (char*)"test_devices", false, true); //Test Button
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence Smoke Devices", (char*)"silence_smoke", false, false); //Silence Button
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test All Devices", (char*)"test_devices", false, true, (char*)"mdi:bell-cog"); //Test Button
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence Smoke Devices", (char*)"silence_smoke", false, false, (char*)"mdi:bell-sleep"); //Silence Button
 }
 
-void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic, bool enabled) {
+void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic, bool enabled, char* icon) {
 	StaticJsonDocument<500> doc;
 
 	char avtytopic[200];
@@ -63,6 +63,7 @@ void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic, 
 		doc["entity_category"] = "diagnostic";
 	if (!enabled)
 		doc["en"] = false;
+	doc["icon"] = icon;
 	char cmdtopic[200];
 	sprintf(cmdtopic, "ws2mqtt/bridge_%08x/command", DEVICE_ID);
 	doc["cmd_t"] = cmdtopic;

--- a/Firmware-ESP/src/homeassistant.cpp
+++ b/Firmware-ESP/src/homeassistant.cpp
@@ -67,7 +67,11 @@ void announceMQTTBridgeEntities() {
 
 	// Restart
 	announceMQTTBridgeButtonEntity((char*)"ESP Restart", (char*)"esp_restart", false, false, (char*)"mdi:restart"); // Restart Button
-	announceMQTTBridgeSensorEntity((char*)"Uptime", (char*)"esp_uptime", (char*)"duration", (char*)"s", true, false, (char*)"mdi:clock"); // Time since last restart
+	announceMQTTBridgeSensorEntity((char*)"ESP Uptime", (char*)"esp_uptime", (char*)"duration", (char*)"s", true, false, (char*)"mdi:clock"); // Time since last restart
+	announceMQTTBridgeSensorEntity((char*)"ESP Restart Reason", (char*)"esp_reset_reason", (char*)"None", (char*)"None", true, false, (char*)"mdi:restart-alert");
+
+	// ESP Info
+	announceMQTTBridgeSensorEntity((char*)"ESP Model", (char*)"esp_model", (char*)"None", (char*)"None", true, false, (char*)"mdi:chip"); // ESP Chip Model
 }
 
 void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic, bool enabled, char* icon) {
@@ -191,6 +195,44 @@ void loopBridgeSensors () {
 		char uptime[5];
 		sprintf(uptime, "%d", esp_timer_get_time()/1000000);
 		sendMQTTBridgeSensor((char*)"esp_uptime", (char*)uptime);
+
+		esp_reset_reason_t reason = esp_reset_reason();
+		char reason_str[20];
+		switch (reason)
+		{
+		case ESP_RST_POWERON:
+			sprintf(reason_str, "%s", "Power On");
+			break;
+		case ESP_RST_SW:
+			sprintf(reason_str, "%s", "Software");
+			break;
+		case ESP_RST_PANIC:
+			sprintf(reason_str, "%s", "Exception/Panic");
+			break;
+		case ESP_RST_INT_WDT:
+			sprintf(reason_str, "%s", "Interupt Watchdog");
+			break;
+		case ESP_RST_TASK_WDT:
+			sprintf(reason_str, "%s", "Task Watchdog");
+			break;
+		case ESP_RST_WDT:
+			sprintf(reason_str, "%s", "Other Watchdog");
+			break;
+		case ESP_RST_DEEPSLEEP:
+			sprintf(reason_str, "%s", "Exit Deep Sleep");
+			break;
+		case ESP_RST_BROWNOUT:
+			sprintf(reason_str, "%s", "Brownout");
+			break;
+		
+		default:
+			sprintf(reason_str, "%s", "Uknown");
+			break;
+		}
+		sendMQTTBridgeSensor((char*)"esp_reset_reason", (char*)reason_str);
+
+		// ESP Chip
+		sendMQTTBridgeSensor((char*)"esp_model", (char*)ESP.getChipModel());
 
 		lastSensorPush = millis();
 	}

--- a/Firmware-ESP/src/homeassistant.cpp
+++ b/Firmware-ESP/src/homeassistant.cpp
@@ -44,7 +44,10 @@ void announceMQTTBridge() {
 }
 
 void announceMQTTBridgeEntities() {
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test All Devices", (char*)"test_devices", false, true, (char*)"mdi:bell-cog"); //Test Button
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test All Devices", (char*)"test_devices", false, true, (char*)"mdi:bell-cog"); //Test All Button
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test Smoke Devices", (char*)"test_smoke", false, false, (char*)"mdi:bell-cog"); //Test Smoke Button
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test CO Devices", (char*)"test_co", false, false, (char*)"mdi:bell-cog"); //Test CO Button
+
 	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence Smoke Devices", (char*)"silence_smoke", false, false, (char*)"mdi:bell-sleep"); //Silence Smoke Button
 	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence CO Devices", (char*)"silence_co", false, false, (char*)"mdi:bell-sleep"); //Silence CO Button
 }
@@ -267,12 +270,18 @@ void removeMQTTButtonEvent(device_t device) {
 
 void handleMQTTCommand(char* command) {
 	if (strncmp(command, "test_devices", 12) == 0) {
-		sendTestButtonMsg();
-	} else if (strncmp(command, "silence_smoke", 15) == 0)
-	{
+		sendTestButtonMsg(DEVICE_TYPE_ALL);
+	} 
+	else if (strncmp(command, "test_smoke", 10) == 0) { 
+		sendTestButtonMsg(DEVICE_TYPE_SMOKE);
+	} 
+	else if (strncmp(command, "test_co", 7) == 0) { 
+		sendTestButtonMsg(DEVICE_TYPE_CO);
+	} 
+	else if (strncmp(command, "silence_smoke", 15) == 0) {
 		sendSilenceButtonMsg(DEVICE_TYPE_SMOKE);
-	} else if (strncmp(command, "silence_co", 10) == 0)
-	{
+	} 
+	else if (strncmp(command, "silence_co", 10) == 0) {
 		sendSilenceButtonMsg(DEVICE_TYPE_CO);
 	}
 

--- a/Firmware-ESP/src/homeassistant.cpp
+++ b/Firmware-ESP/src/homeassistant.cpp
@@ -50,6 +50,9 @@ void announceMQTTBridgeEntities() {
 
 	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence Smoke Devices", (char*)"silence_smoke", false, false, (char*)"mdi:bell-sleep"); //Silence Smoke Button
 	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence CO Devices", (char*)"silence_co", false, false, (char*)"mdi:bell-sleep"); //Silence CO Button
+
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Emergency Smoke", (char*)"emergency_smoke", false, false, (char*)"mdi:bell-sleep"); //Emergency Smoke Button
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Emergency CO", (char*)"emergency_co", false, false, (char*)"mdi:bell-sleep"); //Emergency CO Button
 }
 
 void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic, bool enabled, char* icon) {
@@ -278,11 +281,17 @@ void handleMQTTCommand(char* command) {
 	else if (strncmp(command, "test_co", 7) == 0) { 
 		sendTestButtonMsg(DEVICE_TYPE_CO);
 	} 
-	else if (strncmp(command, "silence_smoke", 15) == 0) {
+	else if (strncmp(command, "silence_smoke", 13) == 0) {
 		sendSilenceButtonMsg(DEVICE_TYPE_SMOKE);
 	} 
 	else if (strncmp(command, "silence_co", 10) == 0) {
 		sendSilenceButtonMsg(DEVICE_TYPE_CO);
+	}
+	else if (strncmp(command, "emergency_smoke", 15) == 0) {
+		sendEmergencyButtonMsg(DEVICE_TYPE_SMOKE);
+	}
+	else if (strncmp(command, "emergency_co", 12) == 0) {
+		sendEmergencyButtonMsg(DEVICE_TYPE_CO);
 	}
 
 }

--- a/Firmware-ESP/src/homeassistant.cpp
+++ b/Firmware-ESP/src/homeassistant.cpp
@@ -44,7 +44,7 @@ void announceMQTTBridge() {
 }
 
 void announceMQTTBridgeEntities() {
-	announceMQTTBridgeButtonEntity("WS2MQTT Test devices", "test_devices", false);
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test devices", (char*)"test_devices", false);
 }
 
 void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic) {
@@ -191,10 +191,10 @@ void sendMQTTState(uint32_t device_id, char* short_name, bool state) {
 }
 
 void sendMQTTDeviceState(device_state_t ds) {
-	sendMQTTState(ds.device_id, "generic_error", ds.generic_error);
-	sendMQTTState(ds.device_id, "docked", ds.docked);
-	sendMQTTState(ds.device_id, "sensor_battery", ds.sensor_battery);
-	sendMQTTState(ds.device_id, "radio_module_battery", ds.radio_module_battery);
+	sendMQTTState(ds.device_id, (char*)"generic_error", ds.generic_error);
+	sendMQTTState(ds.device_id, (char*)"docked", ds.docked);
+	sendMQTTState(ds.device_id, (char*)"sensor_battery", ds.sensor_battery);
+	sendMQTTState(ds.device_id, (char*)"radio_module_battery", ds.radio_module_battery);
 }
 
 void announceMQTTButtonEvent(device_t device) {

--- a/Firmware-ESP/src/homeassistant.cpp
+++ b/Firmware-ESP/src/homeassistant.cpp
@@ -44,8 +44,8 @@ void announceMQTTBridge() {
 }
 
 void announceMQTTBridgeEntities() {
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test devices", (char*)"test_devices", false); //Test Button
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Mute all devices", (char*)"mute_devices", false); //Mute Button
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test All Devices", (char*)"test_devices", false); //Test Button
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence Smoke Devices", (char*)"silence_smoke", false); //Silence Button
 }
 
 void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic) {
@@ -249,7 +249,8 @@ void removeMQTTBinarySensor(device_t device, char* short_name) {
 		sprintf(topic, HA_AUTODISCOVERY_PREFIX"/binary_sensor/ws2mqtt_%d/%s/config", device.device_id, short_name);
 		Serial.println(topic);
 		mqttClient.publish(topic, NULL, true);
-	}
+	} 
+	
 }
 
 void removeMQTTButtonEvent(device_t device) {
@@ -261,8 +262,13 @@ void removeMQTTButtonEvent(device_t device) {
 }
 
 void handleMQTTCommand(char* command) {
-	if (strncmp(command, "test_devices", 12) == 0)
+	if (strncmp(command, "test_devices", 12) == 0) {
 		sendTestButtonMsg();
+	} else if (strncmp(command, "silence_smoke", 15) == 0)
+	{
+		sendSilenceSmokeButtonMsg();
+	}
+
 }
 
 char* modelString(uint16_t model_id) {

--- a/Firmware-ESP/src/homeassistant.cpp
+++ b/Firmware-ESP/src/homeassistant.cpp
@@ -44,7 +44,8 @@ void announceMQTTBridge() {
 }
 
 void announceMQTTBridgeEntities() {
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test devices", (char*)"test_devices", false);
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test devices", (char*)"test_devices", false); //Test Button
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Mute all devices", (char*)"mute_devices", false); //Mute Button
 }
 
 void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic) {

--- a/Firmware-ESP/src/homeassistant.cpp
+++ b/Firmware-ESP/src/homeassistant.cpp
@@ -44,11 +44,11 @@ void announceMQTTBridge() {
 }
 
 void announceMQTTBridgeEntities() {
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test All Devices", (char*)"test_devices", false); //Test Button
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence Smoke Devices", (char*)"silence_smoke", false); //Silence Button
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test All Devices", (char*)"test_devices", false, true); //Test Button
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence Smoke Devices", (char*)"silence_smoke", false, false); //Silence Button
 }
 
-void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic) {
+void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic, bool enabled) {
 	StaticJsonDocument<500> doc;
 
 	char avtytopic[200];
@@ -61,6 +61,8 @@ void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic) 
 	doc["name"] = name;
 	if (diagnostic)
 		doc["entity_category"] = "diagnostic";
+	if (!enabled)
+		doc['en'] = false;
 	char cmdtopic[200];
 	sprintf(cmdtopic, "ws2mqtt/bridge_%08x/command", DEVICE_ID);
 	doc["cmd_t"] = cmdtopic;

--- a/Firmware-ESP/src/homeassistant.cpp
+++ b/Firmware-ESP/src/homeassistant.cpp
@@ -110,7 +110,6 @@ void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic, 
 	}
 }
 
-// remove init_value
 void announceMQTTBridgeSensorEntity(char* name, char* sensor, char* dev_class, char* unit, bool diagnostic, bool enabled, char* icon) {
 	StaticJsonDocument<500> doc;
 
@@ -172,7 +171,7 @@ void sendMQTTBridgeEvent() {
 
 void loopBridgeSensors () {
 	
-	if (millis() - lastSensorPush > BRIDGE_SENSOR_INTERVAL) {
+	if (millis() - lastSensorPush > BRIDGE_SENSOR_INTERVAL * 1000) {
 		// IP Address
 		sendMQTTBridgeSensor((char*)"ip_addr", (char*)WiFi.localIP().toString().c_str());
 

--- a/Firmware-ESP/src/homeassistant.cpp
+++ b/Firmware-ESP/src/homeassistant.cpp
@@ -46,7 +46,7 @@ void announceMQTTBridge() {
 void announceMQTTBridgeEntities() {
 	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test All Devices", (char*)"test_devices", false, true, (char*)"mdi:bell-cog"); //Test Button
 	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence Smoke Devices", (char*)"silence_smoke", false, false, (char*)"mdi:bell-sleep"); //Silence Smoke Button
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence Smoke Devices", (char*)"silence_co", false, false, (char*)"mdi:bell-sleep"); //Silence CO Button
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence CO Devices", (char*)"silence_co", false, false, (char*)"mdi:bell-sleep"); //Silence CO Button
 }
 
 void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic, bool enabled, char* icon) {

--- a/Firmware-ESP/src/homeassistant.cpp
+++ b/Firmware-ESP/src/homeassistant.cpp
@@ -52,12 +52,16 @@ void announceMQTTBridgeEntities() {
 	announceMQTTBridgeButtonEntity((char*)"Test CO Devices", (char*)"test_co", false, false, (char*)"mdi:bell-cog"); //Test CO Button
 
 	// Silence
+#ifdef ENABLE_SILENCE_ALARM
 	announceMQTTBridgeButtonEntity((char*)"Silence Smoke Devices", (char*)"silence_smoke", false, false, (char*)"mdi:bell-sleep"); //Silence Smoke Button
 	announceMQTTBridgeButtonEntity((char*)"Silence CO Devices", (char*)"silence_co", false, false, (char*)"mdi:bell-sleep"); //Silence CO Button
+#endif
 
 	// Emergency
+#ifdef ENABLE_TRIGGER_ALARM
 	announceMQTTBridgeButtonEntity((char*)"Emergency Smoke", (char*)"emergency_smoke", false, false, (char*)"mdi:bell-sleep"); //Emergency Smoke Button
 	announceMQTTBridgeButtonEntity((char*)"Emergency CO", (char*)"emergency_co", false, false, (char*)"mdi:bell-sleep"); //Emergency CO Button
+#endif
 
 	// WiFi Sensors
 	announceMQTTBridgeSensorEntity((char*)"IP Address", (char*)"ip_addr", (char*)"None", (char*)"None", true, true, (char*)"mdi:ip-network"); //IP Address Sensor
@@ -66,7 +70,7 @@ void announceMQTTBridgeEntities() {
 	announceMQTTBridgeSensorEntity((char*)"SSID", (char*)"ssid", (char*)"None", (char*)"None", true, true, (char*)"mdi:wifi"); //Wifi SSID
 
 	// Restart
-	announceMQTTBridgeButtonEntity((char*)"ESP Restart", (char*)"esp_restart", false, false, (char*)"mdi:restart"); // Restart Button
+	announceMQTTBridgeButtonEntity((char*)"ESP Restart", (char*)"esp_restart", true, false, (char*)"mdi:restart"); // Restart Button
 	announceMQTTBridgeSensorEntity((char*)"ESP Uptime", (char*)"esp_uptime", (char*)"duration", (char*)"s", true, false, (char*)"mdi:clock"); // Time since last restart
 	announceMQTTBridgeSensorEntity((char*)"ESP Restart Reason", (char*)"esp_reset_reason", (char*)"None", (char*)"None", true, false, (char*)"mdi:restart-alert");
 
@@ -419,18 +423,22 @@ void handleMQTTCommand(char* command) {
 	else if (strncmp(command, "test_co", 7) == 0) { 
 		sendTestButtonMsg(DEVICE_TYPE_CO);
 	} 
+#ifdef ENABLE_SILENCE_ALARM
 	else if (strncmp(command, "silence_smoke", 13) == 0) {
 		sendSilenceButtonMsg(DEVICE_TYPE_SMOKE);
 	} 
 	else if (strncmp(command, "silence_co", 10) == 0) {
 		sendSilenceButtonMsg(DEVICE_TYPE_CO);
 	}
+#endif
+#ifdef ENABLE_TRIGGER_ALARM
 	else if (strncmp(command, "emergency_smoke", 15) == 0) {
 		sendEmergencyButtonMsg(DEVICE_TYPE_SMOKE);
 	}
 	else if (strncmp(command, "emergency_co", 12) == 0) {
 		sendEmergencyButtonMsg(DEVICE_TYPE_CO);
 	}
+#endif
 	else if (strncmp(command, "esp_restart", 11) ==0) {
 		ESP.restart();
 	}

--- a/Firmware-ESP/src/homeassistant.cpp
+++ b/Firmware-ESP/src/homeassistant.cpp
@@ -45,7 +45,8 @@ void announceMQTTBridge() {
 
 void announceMQTTBridgeEntities() {
 	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Test All Devices", (char*)"test_devices", false, true, (char*)"mdi:bell-cog"); //Test Button
-	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence Smoke Devices", (char*)"silence_smoke", false, false, (char*)"mdi:bell-sleep"); //Silence Button
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence Smoke Devices", (char*)"silence_smoke", false, false, (char*)"mdi:bell-sleep"); //Silence Smoke Button
+	announceMQTTBridgeButtonEntity((char*)"WS2MQTT Silence Smoke Devices", (char*)"silence_co", false, false, (char*)"mdi:bell-sleep"); //Silence CO Button
 }
 
 void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic, bool enabled, char* icon) {
@@ -269,7 +270,10 @@ void handleMQTTCommand(char* command) {
 		sendTestButtonMsg();
 	} else if (strncmp(command, "silence_smoke", 15) == 0)
 	{
-		sendSilenceSmokeButtonMsg();
+		sendSilenceButtonMsg(DEVICE_TYPE_SMOKE);
+	} else if (strncmp(command, "silence_co", 10) == 0)
+	{
+		sendSilenceButtonMsg(DEVICE_TYPE_CO);
 	}
 
 }

--- a/Firmware-ESP/src/homeassistant.cpp
+++ b/Firmware-ESP/src/homeassistant.cpp
@@ -62,7 +62,7 @@ void announceMQTTBridgeButtonEntity(char* name, char* command, bool diagnostic, 
 	if (diagnostic)
 		doc["entity_category"] = "diagnostic";
 	if (!enabled)
-		doc['en'] = false;
+		doc["en"] = false;
 	char cmdtopic[200];
 	sprintf(cmdtopic, "ws2mqtt/bridge_%08x/command", DEVICE_ID);
 	doc["cmd_t"] = cmdtopic;

--- a/Firmware-ESP/src/main.cpp
+++ b/Firmware-ESP/src/main.cpp
@@ -37,6 +37,8 @@ void loop() {
 	receiveSPIMessage(&handleRX);
 	loopMQTT();
 	
+	loopBridgeSensors();
+
 	loopOTA();
 
 	loopUpdateSIDMap();

--- a/Firmware-ESP/src/main.cpp
+++ b/Firmware-ESP/src/main.cpp
@@ -18,6 +18,7 @@ void setup() {
 	setupSPI();
 	setupWifi();
 	setupMQTT();
+	setupOTA();
 
 	sendDiagnosticRequest();
 	sendQuerySIDMap();
@@ -35,6 +36,8 @@ void loopUpdateSIDMap() {
 void loop() {
 	receiveSPIMessage(&handleRX);
 	loopMQTT();
+	
+	loopOTA();
 
 	loopUpdateSIDMap();
 	loopTX();

--- a/Firmware-ESP/src/wifi.cpp
+++ b/Firmware-ESP/src/wifi.cpp
@@ -81,3 +81,15 @@ void loopMQTT() {
 	} else
 		mqttClient.loop();
 }
+
+void setupOTA() {
+	// OTA Configiration and Enable OTA
+	Serial.println("Enabling OTA Feature");
+	ArduinoOTA.setPassword(OTA_PASSWORD);
+	ArduinoOTA.begin();
+}
+
+void loopOTA() {
+	// OTA Handle
+  	ArduinoOTA.handle();
+}

--- a/Firmware-ESP/src/wifi.cpp
+++ b/Firmware-ESP/src/wifi.cpp
@@ -9,6 +9,9 @@ unsigned long lastReconnectAttempt = 0;
 void setupWifi() {
 	Serial.println("Connecting to Wifi");
 
+	char host[32];
+	sprintf(host, "ws2mqtt_%08x", DEVICE_ID);
+	WiFi.setHostname(host);
 	WiFi.mode(WIFI_STA);
 	WiFi.begin(WIFI_SSID, WIFI_PSK);
 

--- a/Firmware-ESP/src/wisafe2_tx.cpp
+++ b/Firmware-ESP/src/wisafe2_tx.cpp
@@ -58,6 +58,22 @@ void sendTestButtonMsg() {
 	handleTX((uint8_t*)&pkt, sizeof(pkt));
 }
 
+void sendSilenceSmokeButtonMsg() {
+	Serial.printf("Sending silence smoke message\n");
+
+	pkt_tx_silence_smoke_button_t pkt;
+	memset(&pkt, 0, sizeof(pkt));
+
+	pkt.cmd = SPI_TX_SILENCE_SMOKE_BUTTON;
+	pkt.device_id = DEVICE_ID;
+	pkt.device_type = DEVICE_TYPE_SMOKE;
+	pkt._unknown = 0x01;
+	pkt.stop = SPI_STOP_WORD;
+
+	handleTX((uint8_t*)&pkt, sizeof(pkt));
+}
+
+
 void sendDiagnosticRequest() {
 	Serial.printf("Sending diagnostic request\n");
 

--- a/Firmware-ESP/src/wisafe2_tx.cpp
+++ b/Firmware-ESP/src/wisafe2_tx.cpp
@@ -42,7 +42,7 @@ void sendWelcomeMsg() {
 	handleTX((uint8_t*)&pkt, sizeof(pkt));
 }
 
-void sendTestButtonMsg() {
+void sendTestButtonMsg(uint8_t device_type) {
 	Serial.printf("Sending test button message\n");
 
 	pkt_tx_event_button_t pkt;
@@ -50,7 +50,7 @@ void sendTestButtonMsg() {
 
 	pkt.cmd = SPI_TX_EVENT_BUTTON;
 	pkt.device_id = DEVICE_ID;
-	pkt.device_type = DEVICE_TYPE_ALL;
+	pkt.device_type = device_type;
 	pkt._unknown = 0x01;
 	pkt.model = 0x047C;
 	pkt.stop = SPI_STOP_WORD;

--- a/Firmware-ESP/src/wisafe2_tx.cpp
+++ b/Firmware-ESP/src/wisafe2_tx.cpp
@@ -58,15 +58,15 @@ void sendTestButtonMsg() {
 	handleTX((uint8_t*)&pkt, sizeof(pkt));
 }
 
-void sendSilenceSmokeButtonMsg() {
+void sendSilenceButtonMsg(uint8_t device_type) {
 	Serial.printf("Sending silence smoke message\n");
 
-	pkt_tx_silence_smoke_button_t pkt;
+	pkt_tx_silence_button_t pkt;
 	memset(&pkt, 0, sizeof(pkt));
 
-	pkt.cmd = SPI_TX_SILENCE_SMOKE_BUTTON;
+	pkt.cmd = SPI_TX_SILENCE_BUTTON;
 	pkt.device_id = DEVICE_ID;
-	pkt.device_type = DEVICE_TYPE_SMOKE;
+	pkt.device_type = device_type;
 	pkt._unknown = 0x01;
 	pkt.stop = SPI_STOP_WORD;
 

--- a/Firmware-ESP/src/wisafe2_tx.cpp
+++ b/Firmware-ESP/src/wisafe2_tx.cpp
@@ -43,7 +43,7 @@ void sendWelcomeMsg() {
 }
 
 void sendTestButtonMsg(uint8_t device_type) {
-	Serial.printf("Sending test button message\n");
+	Serial.printf("Sending test message\n");
 
 	pkt_tx_event_button_t pkt;
 	memset(&pkt, 0, sizeof(pkt));
@@ -59,7 +59,7 @@ void sendTestButtonMsg(uint8_t device_type) {
 }
 
 void sendSilenceButtonMsg(uint8_t device_type) {
-	Serial.printf("Sending silence smoke message\n");
+	Serial.printf("Sending silence message\n");
 
 	pkt_tx_silence_button_t pkt;
 	memset(&pkt, 0, sizeof(pkt));
@@ -68,6 +68,21 @@ void sendSilenceButtonMsg(uint8_t device_type) {
 	pkt.device_id = DEVICE_ID;
 	pkt.device_type = device_type;
 	pkt._unknown = 0x01;
+	pkt.stop = SPI_STOP_WORD;
+
+	handleTX((uint8_t*)&pkt, sizeof(pkt));
+}
+
+void sendEmergencyButtonMsg(uint8_t device_type) {
+	Serial.printf("Sending emergency message\n");
+
+	pkt_tx_emergency_button_t pkt;
+	memset(&pkt, 0, sizeof(pkt));
+
+	pkt.cmd = SPI_TX_EMERGENCY_BUTTON;
+	pkt.device_id = DEVICE_ID;
+	pkt.device_type = device_type;
+	pkt._unknown = 0x00;
 	pkt.stop = SPI_STOP_WORD;
 
 	handleTX((uint8_t*)&pkt, sizeof(pkt));


### PR DESCRIPTION
Firstly, thanks for the great work!!!

I've made a number of tweaks and improvements as follows:
- Resolved ISO C++ String to char* compiler errors (quick fix rather than the perfect solution)
- Added additional buttons for the below. The silence buttons would satisfy #2. They are all disabled by default in HA so can be enabled only by those who wish: 
  - testing smoke/heat device only
  - testing CO device only (don't have CO device so haven't tested)
  - silence as a smoke device
  - silence as a CO device (don't have CO device so haven't tested)
  - trigger a smoke emergency
  - trigger a CO emergency (don't have CO device so haven't tested)
- Added default icons to the Home Assistant buttons
- Implemented OTA updates. The OTA password can be set in credentials.h and would also need to be put in platformio.ini. The IP of the device needs to be set in platformio.ini also.
- Added additional diagnostic sensors (updated every 10 seconds) to the bridge device as follows:
  - IP address of the bridge (helpful for OTA updates)
  - MAC address of the bridge
  - SSID of the access point the bridge is connected to
  - The RSSI signal strength (dBm)

**Possible To Do**
Thinking of doing the below at some point in the future. These would mainly be for productising the bridge so I haven't bothered so far.
- Captive portal to set up WiFi and MQTT details on initial set up
- Button to initiate pairing of the WS2 module
- Sensor to show pairing status of the WS2 module